### PR TITLE
fix: concurrency problem when multiple users exec same exercise

### DIFF
--- a/services/docker_service.py
+++ b/services/docker_service.py
@@ -25,18 +25,14 @@ class DockerService():
     processedImageName = self.dockerImageNameService.getProcessedImageName(imageName)
     self.dockerClient.images.pull(processedImageName)
 
-  def runAndGetContainer(
-    self,
-    imageName: DockerImageName,
-    testCommand: str
-  ) -> DockerContainer:
+  def runAndGetContainer(self, imageName: DockerImageName, testCommand: str, identifier: str) -> DockerContainer:
     processedImageName = self.dockerImageNameService.getProcessedImageName(imageName)
     container = self.dockerClient.containers.run(
       processedImageName,
       testCommand,
       detach=True,
       working_dir=env.DOCKER_WORKDIR,
-      volumes=[f"{env.PROJECT_TMP_DIRECTORY}:{env.DOCKER_TMP_DIRECTORY}"],
+      volumes=[f"{env.PROJECT_TMP_DIRECTORY}/{identifier}:{env.DOCKER_TMP_DIRECTORY}"],
       network_mode="none",
       pids_limit=128,
       kernel_memory="768m",

--- a/services/runner_file_service.py
+++ b/services/runner_file_service.py
@@ -1,23 +1,23 @@
-import env
-
-from typing import List
+import shutil
+import uuid
 from pathlib import Path
+from typing import List
+
+import env
 from models.run_request import RunRequestFile
 
+
 class RunnerFileService():
-  def createFile(self, filename: str, content: str) -> None:
-    file = Path(f"{env.PROJECT_TMP_DIRECTORY}/{filename}");
-    file.parent.mkdir(exist_ok=True, parents=True);
+  def createFile(self, filename: str, content: str, identifier: uuid) -> None:
+    file = Path(f"{env.PROJECT_TMP_DIRECTORY}/{identifier}/{filename}")
+    file.parent.mkdir(exist_ok=True, parents=True)
     file.write_text(content)
 
-  def createFiles(self, files: List[RunRequestFile]) -> None:
+  def createFiles(self, files: List[RunRequestFile], identifier: uuid) -> None:
     for file in files:
-      self.createFile(file.fileName, file.content)
+      self.createFile(file.fileName, file.content, identifier)
 
-  def deleteFile(self, fileName: str) -> None:
-    file = Path(f"{env.PROJECT_TMP_DIRECTORY}/{fileName}");
-    file.unlink()
-
-  def deleteFiles(self, files: List[RunRequestFile]) -> None:
-    for file in files:
-      self.deleteFile(file.fileName)
+  @staticmethod
+  def deleteDirectory(identifier: uuid) -> None:
+    directory = Path(f"{env.PROJECT_TMP_DIRECTORY}/{identifier}")
+    shutil.rmtree(directory)

--- a/services/runner_service.py
+++ b/services/runner_service.py
@@ -32,7 +32,7 @@ class RunnerService():
 
     self.runnerFileService.createFiles(files, uniqueIdentifier)
 
-    dockerContainerOutput = self.runTestAndGetOutput(dockerImageName, testCommand)
+    dockerContainerOutput = self.runTestAndGetOutput(dockerImageName, testCommand, uniqueIdentifier)
 
     testPassed = None
 
@@ -43,9 +43,9 @@ class RunnerService():
 
     return { 'passed': testPassed, 'output': dockerContainerOutput }
 
-  def runTestAndGetOutput(self, dockerImageName: DockerImageName, testCommand: str) -> str:
+  def runTestAndGetOutput(self, dockerImageName: DockerImageName, testCommand: str, identifier: uuid) -> str:
     self.dockerService.pullImage(dockerImageName)
-    dockerContainer = self.dockerService.runAndGetContainer(dockerImageName, testCommand)
+    dockerContainer = self.dockerService.runAndGetContainer(dockerImageName, testCommand, identifier)
     dockerContainerLogStream = dockerContainer.logs()
     dockerContainer.stop()
     dockerContainer.remove()


### PR DESCRIPTION
This commit fixes the concurrency problem when multiple users execute the same exercise.

The root of the problem is the file creation and deletion. Before sending the files to the Docker context, the application saves them on the filesystem. After the execution, the application deletes the created files.

The problem occurs because the files are created and deleted with the same name/identifier on multiple sessions. The application crashes when trying to delete the resource that possibly is previously deleted.

The solution applied on this commit adds a new identifier to each request. This identifier is used to create a folder responsible for retaining all files of each request. After the test execution, the folder created to save the request files is deleted.

The identifier strategy is a UUID version 4. The probability of collision is one in 2.71 x 10^18.