### PR TITLE
Removing docker container manipulation

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -1,0 +1,22 @@
+from dependency_container import runnerService
+from models.run_request import RunRequestBody
+
+
+def run():
+    body = RunRequestBody(
+        testCommand="jest",
+        files=[
+            {"fileName": "sum.js",
+             "content": "\"use strict\";\n\nfunction sum(a, b) {\n  return a + b;\n}\n\nmodule.exports = { sum };\n"},
+            {"fileName": "sum.test.js",
+             "content": "\"use strict\";\n\nconst { sum } = require(\"./sum.js\");\n\ntest(\"should return proper "
+                        "result\", () => {\n  expect(sum(1, 1)).toBe(2);\n  expect(sum(-1, 1)).toBe(0);\n  expect("
+                        "sum(-1, -1)).toBe(-2);\n});"}
+        ],
+        testingEnvironment="javascript-jest"
+    )
+    runnerService.run(body)
+
+
+if __name__ == "__main__":
+    run()

--- a/services/docker_service.py
+++ b/services/docker_service.py
@@ -35,6 +35,7 @@ class DockerService():
       processedImageName,
       testCommand,
       detach=True,
+      auto_remove=True,
       working_dir=env.DOCKER_WORKDIR,
       volumes=[f"{env.PROJECT_TMP_DIRECTORY}:{env.DOCKER_TMP_DIRECTORY}"],
       network_mode="none",

--- a/services/runner_service.py
+++ b/services/runner_service.py
@@ -39,11 +39,8 @@ class RunnerService():
     return { 'passed': testPassed, 'output': dockerContainerOutput }
 
   def runTestAndGetOutput(self, dockerImageName: DockerImageName, testCommand: str) -> str:
-    self.dockerService.pullImage(dockerImageName)
     dockerContainer = self.dockerService.runAndGetContainer(dockerImageName, testCommand)
     dockerContainerLogStream = dockerContainer.logs()
-    dockerContainer.stop()
-    dockerContainer.remove()
     
     dockerContainerOutput = ""
 


### PR DESCRIPTION
Removing the pulling image, remove and stop container actions. These actions can be handled directly by Docker Engine.

The image pulling and container stopping are automatically done by the engine. The definition of these actions makes the program run twice.

The container removal can be defined on the run arguments. The auto_remove argument configures the engine to remove the container after it stops.